### PR TITLE
feat: [closes #18] define TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "module": "src/index.js",
   "type": "module",
+  "types": "src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./firebase": "./src/firebase.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,101 @@
+declare module 'trystero' {
+  type Metadata = Record<string, number | string | boolean | null | undefined>
+
+  interface BitTorrentRoomConfig {
+    trackerUrls?: string[]
+    trackerRedundancy?: number
+  }
+
+  interface FirebaseRoomConfig {
+    firebaseApp?: string
+    rootPath?: string
+  }
+
+  interface IpfsRoomConfig {
+    swarmAddresses?: string
+  }
+
+  export interface BaseRoomConfig {
+    appId: string
+    password?: string
+    rtcConfig?: RTCConfiguration
+  }
+
+  export type RoomConfig = BaseRoomConfig &
+    (BitTorrentRoomConfig | FirebaseRoomConfig | IpfsRoomConfig)
+
+  export interface ActionSender<T> {
+    (
+      data: T,
+      targetPeers?: string[],
+      metadata?: Metadata,
+      progress?: (percent: number, peerId: string) => void
+    ): Promise<Array<undefined>>
+  }
+
+  export interface ActionReceiver<T> {
+    (receiver: (data: T, peerId?: string, metadata?: Metadata) => void): void
+  }
+
+  export interface ActionProgress {
+    (
+      progressHandler: (
+        percent: number,
+        peerId: string,
+        metadata?: Metadata
+      ) => void
+    ): void
+  }
+
+  export interface Room {
+    makeAction: <T>(
+      namespace: string
+    ) => [ActionSender<T>, ActionReceiver<T>, ActionProgress]
+
+    ping: (id: string) => Promise<number>
+
+    leave: () => void
+
+    getPeers: () => string[]
+
+    addStream: (
+      stream: MediaStream,
+      peerId?: string,
+      metadata?: Metadata
+    ) => Promise<void>[]
+
+    removeStream: (stream: MediaStream, peerId?: string) => void
+
+    addTrack: (
+      track: MediaStreamTrack,
+      stream: MediaStream,
+      peerId?: string,
+      metadata?: Metadata
+    ) => Promise<void>[]
+
+    removeTrack: (
+      track: MediaStreamTrack,
+      stream: MediaStream,
+      peerId?: string
+    ) => void
+
+    replaceTrack: (
+      oldTrack: MediaStreamTrack,
+      newTrack: MediaStreamTrack,
+      stream: MediaStream,
+      peerId?: string
+    ) => Promise<void>[]
+
+    onPeerJoin: (fn: (peerId: string) => void) => void
+
+    onPeerLeave: (fn: (peerId: string) => void) => void
+
+    onPeerStream: (fn: (stream: MediaStream, peerId: string) => void) => void
+
+    onPeerTrack: (
+      fn: (track: MediaStreamTrack, stream: MediaStream, peerId: string) => void
+    ) => void
+  }
+
+  export function joinRoom(config: RoomConfig, roomId: string): Room
+}


### PR DESCRIPTION
This PR satisfies #18 by defining TypeScript types. This is a [copy/paste (with some fixes) from my own project](https://github.com/jeremyckahn/chitchatter/blob/f0a440491094da1917e1e04d7cc0782576358dd2/src/react-app-env.d.ts#L4-L102) that uses Trystero, and it seems to have been working well for the last few weeks. I haven't used every part of the API yet (such as media tracks) so I don't know for certain if those type definitions are correct.