### PR TITLE
fix: Make ActionReceiver peerId required

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,7 +21,7 @@ declare module 'trystero' {
   }
 
   export interface ActionReceiver<T> {
-    (receiver: (data: T, peerId?: string, metadata?: Metadata) => void): void
+    (receiver: (data: T, peerId: string, metadata?: Metadata) => void): void
   }
 
   export interface ActionProgress {


### PR DESCRIPTION
It seems that I made a small error in #22. Action receivers always receive a `peerId` parameter, but the types currently indicate otherwise: https://github.com/dmotz/trystero/pull/22/files#diff-619cc2239a7eb4ef05041767e6ab0e4fb069e98ee9d2c83c2d8e1865c475e141R36-R38

This is resulting in some needlessly defensive downstream code: https://github.com/jeremyckahn/chitchatter/pull/28/files#diff-5f4fdd09b63db0f2d456592dfcddb1f7fac34223732a923cc23902a12ee00366R151-R153

This PR closes that gap.