### PR TITLE
types: add getOccupants to firebase module

### DIFF
--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -12,5 +12,10 @@ declare module 'trystero/firebase' {
     roomId: string
   ): Room
 
+  export function getOccupants(
+    config: BaseRoomConfig & FirebaseRoomConfig,
+    roomId: string
+  ): Promise<string[]>
+
   export * from 'trystero'
 }


### PR DESCRIPTION
Noticed that firebase types were missing getOccupants.

This PR should add the missing type.