### PR TITLE
fix: Add `metadata` to `onPeerStream` type signature

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -84,7 +84,9 @@ declare module 'trystero' {
 
     onPeerLeave: (fn: (peerId: string) => void) => void
 
-    onPeerStream: (fn: (stream: MediaStream, peerId: string) => void) => void
+    onPeerStream: (
+      fn: (stream: MediaStream, peerId: string, metadata: Metadata) => void
+    ) => void;
 
     onPeerTrack: (
       fn: (track: MediaStreamTrack, stream: MediaStream, peerId: string) => void


### PR DESCRIPTION
This PR defines the `metadata` parameter typing for the [`onPeerStream` callback](https://github.com/dmotz/trystero#onpeerstreamcallback), which I seem to have missed in #22 (sorry about that!).