### PR TITLE
feat: Change `getPeers` to return `simple-peer-light` instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,9 +414,9 @@ Returns an object with the following methods:
 - ### `getPeers()`
 
   Returns a map of
-  [`simple-peer-light`](https://github.com/mitschabaude/simple-peer-light)
-  instances that represent the peers present in room (not including the local
-  user). The keys of this object are the respective peers' IDs.
+  [`RTCPeerConnection`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection)s
+  for the peers present in room (not including the local user). The keys of
+  this object are the respective peers' IDs.
 
 - ### `addStream(stream, [targetPeers], [metadata])`
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,10 @@ Returns an object with the following methods:
 
 - ### `getPeers()`
 
-  Returns a list of peer IDs present in room (not including the local user).
+  Returns a map of
+  [`simple-peer-light`](https://github.com/mitschabaude/simple-peer-light)
+  instances that represent the peers present in room (not including the local
+  user). The keys of this object are the respective peers' IDs.
 
 - ### `addStream(stream, [targetPeers], [metadata])`
 

--- a/docs/site.js
+++ b/docs/site.js
@@ -123,7 +123,7 @@ function removeCursor(id) {
 }
 
 function updatePeerInfo() {
-  const count = room.getPeers().length
+  const count = Object.keys(room.getPeers()).length
   peerInfo.innerHTML = count
     ? `Right now <em>${count}</em> other peer${
         count === 1 ? ' is' : 's are'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,9 +50,7 @@ declare module 'trystero' {
 
     leave: () => void
 
-    // TODO: Define types for simple-peer-light instances, which is what the
-    // `any` here represents.
-    getPeers: () => Record<string, any>
+    getPeers: () => Record<string, RTCPeerConnection>
 
     addStream: (
       stream: MediaStream,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,3 @@
-import Peer from 'simple-peer-light'
-
 declare module 'trystero' {
   import {TorrentRoomConfig} from 'trystero/torrent'
 
@@ -52,7 +50,9 @@ declare module 'trystero' {
 
     leave: () => void
 
-    getPeers: () => Record<string, Peer>
+    // TODO: Define types for simple-peer-light instances, which is what the
+    // `any` here represents.
+    getPeers: () => Record<string, any>
 
     addStream: (
       stream: MediaStream,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import Peer from 'simple-peer-light'
+
 declare module 'trystero' {
   import {TorrentRoomConfig} from 'trystero/torrent'
 
@@ -50,7 +52,7 @@ declare module 'trystero' {
 
     leave: () => void
 
-    getPeers: () => string[]
+    getPeers: () => Record<string, Peer>
 
     addStream: (
       stream: MediaStream,

--- a/src/room.js
+++ b/src/room.js
@@ -4,6 +4,7 @@ import {
   encodeBytes,
   entries,
   events,
+  fromEntries,
   keys,
   libName,
   mkErr,
@@ -329,7 +330,8 @@ export default (onPeer, onSelfLeave) => {
       onSelfLeave()
     },
 
-    getPeers: () => peerMap,
+    getPeers: () =>
+      fromEntries(entries(peerMap).map(([id, peer]) => [id, peer._pc])),
 
     addStream: (stream, targets, meta) =>
       iterate(targets, async (id, peer) => {

--- a/src/room.js
+++ b/src/room.js
@@ -329,7 +329,7 @@ export default (onPeer, onSelfLeave) => {
       onSelfLeave()
     },
 
-    getPeers: () => keys(peerMap),
+    getPeers: () => peerMap,
 
     addStream: (stream, targets, meta) =>
       iterate(targets, async (id, peer) => {


### PR DESCRIPTION
> BREAKING CHANGE: This alters the return type for `getPeers`

I'd like to propose a breaking API change to the `getPeers` method. Presently Trystero hides the `simple-peer-light` object instances from the user. This simplicity is usually good, but it prevents some important functionality. In my use case, I'd like to examine the `simple-peer-light`s' `_pc` (`RTCPeerConnection`) properties to [determine if peers are connected directly or via a relay server](https://stackoverflow.com/a/61571171). If the latter, I'd like to prevent some high-bandwidth operations in order to better manage the load on the relay server.

If changing the API in a backwards incompatible way is undesirable, I'm willing to change this PR to introduce a new, separate API (called something like `getPeerObjects`). Please let me know which approach would be preferable. 