### PR TITLE
feat: add addTransceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,25 @@ Returns an object with the following methods:
   - `targetPeers` - **(optional)** If specified, the track is replaced only for
     the target peer ID (string) or list of peer IDs (array).
 
+- ### `addTransceiver(track, stream, [sendEncodings], [codecPreferences], [targetPeers], [metadata])`
+
+  Adds a new media track to a stream with RTP sender encodings.
+
+  - `track` - A `MediaStreamTrack` to add to an existing stream.
+
+  - `stream` - The target `MediaStream` to attach the new track to.
+
+  - `sendEncodings` - **(optional)** An Array of `RTCRtpEncodingParameters`
+
+  - `codecPreferences` - **(optional)** An Array of preferred `RTCRtpCodecCapability` to use
+
+  - `targetPeers` - **(optional)** If specified, the track is sent only to the
+    target peer ID (string) or list of peer IDs (array).
+
+  - `metadata` - **(optional)** Additional metadata (any serializable type) to
+    be sent with the track. See `metadata` notes for `addStream()` above for
+    more details.
+
 - ### `onPeerJoin(callback)`
 
   Registers a callback function that will be called when a peer joins the room.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -80,6 +80,15 @@ declare module 'trystero' {
       targetPeers?: TargetPeers
     ) => Promise<void>[]
 
+    addTransceiver: (
+      track: MediaStreamTrack,
+      stream: MediaStream,
+      sendEncodings?: RTCRtpCodingParameters[],
+      codecPreferences?: RTCRtpCodecCapability[],
+      targetPeers?: TargetPeers,
+      metadata?: Metadata
+    ) => Promise<void>[]
+
     onPeerJoin: (fn: (peerId: string) => void) => void
 
     onPeerLeave: (fn: (peerId: string) => void) => void

--- a/src/room.js
+++ b/src/room.js
@@ -366,6 +366,19 @@ export default (onPeer, onSelfLeave) => {
         peer.replaceTrack(oldTrack, newTrack, stream)
       }),
 
+    addTransceiver: (track, stream, sendEncodings = [], codecPreferences = [], targets, meta) =>
+      iterate(targets, async (id, peer) => {
+        if (meta) {
+          await sendTrackMeta(meta, id)
+        }
+
+        const transceiver = peer.addTransceiver(track, {
+          streams: [stream],
+          sendEncodings
+        })
+        transceiver.setCodecPreferences(codecPreferences)
+      }),
+
     onPeerJoin: f => (onPeerJoin = f),
 
     onPeerLeave: f => (onPeerLeave = f),


### PR DESCRIPTION
The browser will default to VP8 or h264 encodings unless certain RTCRtpEncodingParameters are specified.  To support codecs like AV1, addTransceiver needs to be used instead of addTrack so the correct senderEncodings can be specified and preferred codecs can be set.

For example:
```
const sendEncodings = [{
  active: true,
  priority: "low",
  rid: "0",
  scalabilityMode: "L1T2",
  scaleResolutionDownBy: 1
} as RTCRtpEncodingParameters]
const codecPreferences = [
  RTCRtpSender.getCapabilities('video').
    codecs.find(codec => codec.mimeType == 'video/AV1')]
addTransceiver(track, stream, sendEncodings, codecPreferences)
```

See https://groups.google.com/g/discuss-webrtc/c/-QQ3pxrl-fw?pli=1