### PR TITLE
feat(torrent): `getTrackers()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,24 @@ Returns an object with the following methods:
 A unique ID string other peers will know the local user as globally across
 rooms.
 
+### `getTrackers`
+
+**(🌊 BitTorrent only)** Returns an object of BitTorrent tracker URL keys
+mapped to their WebSocket connections. This can be useful for determining the
+state of user's connection to the trackers and handling any connection
+failures.
+
+Example:
+
+```javascript
+console.log(trystero.getTrackers())
+// => Object {
+//  "wss://fediverse.tv/tracker/socket": WebSocket,
+//  "wss://tracker.files.fm:7073/announce": WebSocket,
+//  "wss://tracker.openwebtorrent.com": WebSocket
+//  }
+```
+
 ### `getOccupants(config, namespace)`
 
 **(🔥 Firebase only)** Returns a promise that resolves to a list of user IDs

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export {joinRoom, selfId} from './torrent.js'
+export {joinRoom, selfId, getTrackerConnections} from './torrent.js'

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export {joinRoom, selfId, getTrackerConnections} from './torrent.js'
+export {joinRoom, selfId, getTrackers} from './torrent.js'

--- a/src/torrent.d.ts
+++ b/src/torrent.d.ts
@@ -11,7 +11,7 @@ declare module 'trystero/torrent' {
     roomId: string
   ): Room
 
-  export function getTrackerConnections(): Record<string, Promise<WebSocket>>
+  export function getTrackers(): Record<string, Promise<WebSocket>>
 
   export * from 'trystero'
 }

--- a/src/torrent.d.ts
+++ b/src/torrent.d.ts
@@ -11,7 +11,7 @@ declare module 'trystero/torrent' {
     roomId: string
   ): Room
 
-  export function getTrackers(): Record<string, Promise<WebSocket>>
+  export function getTrackers(): Record<string, WebSocket>
 
   export * from 'trystero'
 }

--- a/src/torrent.d.ts
+++ b/src/torrent.d.ts
@@ -11,5 +11,7 @@ declare module 'trystero/torrent' {
     roomId: string
   ): Room
 
+  export function getTrackerConnections(): Record<string, Promise<WebSocket>>
+
   export * from 'trystero'
 }

--- a/src/torrent.js
+++ b/src/torrent.js
@@ -278,7 +278,7 @@ export const joinRoom = initGuard(occupiedRooms, (config, ns) => {
   )
 })
 
-export const getTrackerConnections = () => {
+export const getTrackers = () => {
   return { ...sockets }
 }
 

--- a/src/torrent.js
+++ b/src/torrent.js
@@ -278,4 +278,8 @@ export const joinRoom = initGuard(occupiedRooms, (config, ns) => {
   )
 })
 
+export const getTrackerConnections = () => {
+  return { ...sockets }
+}
+
 export {selfId} from './utils.js'

--- a/src/torrent.js
+++ b/src/torrent.js
@@ -201,7 +201,7 @@ export const joinRoom = initGuard(occupiedRooms, (config, ns) => {
         sockets[url] = socket
 
         socket.addEventListener('open', () => {
-          // Reset the timeout for this tracker
+          // Reset the retry timeout for this tracker
           socketRetryTimeouts[url] = trackerRetrySecs * 1000
           res(socket)
         })

--- a/src/torrent.js
+++ b/src/torrent.js
@@ -192,9 +192,10 @@ export const joinRoom = initGuard(occupiedRooms, (config, ns) => {
         ...socketListeners[url],
         [infoHash]: onSocketMessage
       }
-      sockets[url] = new Promise(res => {
+      sockets[url] = new Promise((res, rej) => {
         const socket = new WebSocket(url)
         socket.onopen = res.bind(null, socket)
+        socket.onerror = rej
         socket.onmessage = e =>
           values(socketListeners[url]).forEach(f => f(socket, e))
       })

--- a/src/torrent.js
+++ b/src/torrent.js
@@ -195,14 +195,14 @@ export const joinRoom = initGuard(occupiedRooms, (config, ns) => {
         ...socketListeners[url],
         [infoHash]: onSocketMessage
       }
-      socketPromises[url] = new Promise((res, rej) => {
+      socketPromises[url] = new Promise(res => {
         const socket = new WebSocket(url)
         sockets[url] = socket
-        socket.onopen = res.bind(null, socket)
-        socket.onerror = rej
-        socket.onmessage = e =>
-          values(socketListeners[url]).forEach(f => f(socket, e))
 
+        socket.addEventListener('open', res.bind(null, socket))
+        socket.addEventListener('message', e =>
+          values(socketListeners[url]).forEach(f => f(socket, e))
+        )
         socket.addEventListener('close', async () => {
           await sleep(trackerRetrySecs * 1000)
           makeSocket(url, infoHash, true)

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,3 +75,8 @@ export const combineChunks = chunks => {
 
   return full
 }
+
+export const sleep = (milliseconds) =>
+  new Promise(res => {
+    setTimeout(res, milliseconds)
+  })


### PR DESCRIPTION
This PR introduces a new BitTorrent-specific function for getting direct access to the WebSocket tracker connections. I needed to access these WebSockets in order to evaluate their `readyState`s to potentially present a troubleshooting UI if no successful connection is made.

This PR also implements retry logic if the WebSocket tracker connection is closed.

This may be a naive implementation, but it seemed like the simplest way to meet the need. Let me know what you think!