### PR TITLE
Enable `joinRoom` and `makeAction` as React Hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,57 @@ room.onPeerLeave(peerId =>
 > will be received on the other side as the same type (a number as a number,
 > a string as a string, an object as an object, binary as binary, etc.).
 
+## React Hooks
+
+The `joinRoom` and `makeAction` functions are idempotent and ready for use as React Hooks.
+
+Create a room and define actions inline to make any React component instantly multiplayer. Here is a simple example of users exchanging their favorite color.
+
+```jsx
+  import React, { useEffect } from 'react'
+
+  const FavColorComponent = () => {
+    // Create the room and an action to ask other users about their favorite color
+    const room = joinRoom({appId: 'x-mas'}, 'buddy_elf')
+    const [sendFavColor, receiveFavColor] = room.makeAction('fav_col')
+    const [sendFavColorResponse, receiveFavColorResponse] 
+      = room.makeAction('fav_col_res')
+
+    // Define a default favorite color as a state variable
+    const [myFavoriteColor, setMyFavoriteColor] = useState('red')
+    const handleChange = (e) => {
+      setMyFavoriteColor(e.target.value);
+    };
+
+    // Setup response for receiving a request for our favorite color
+    useEffect(() => {
+      receiveColor(data, peerId) => {
+        console.log(`Peer with ID ${peerId} has a favorite color! ${data}`);
+        sendColorResponse(myFavoriteColor)
+      }
+      // This useEffect hook will run everytime myFavoriteColor is updated,
+      // ensuring we always respond with our current favorite color
+    }, [myFavoriteColor])
+
+    // Setup a response for receiving a response to our request for a favorite color
+    useEffect(() => {
+      receiveColorResponse((data) => {
+        console.log(`Peer with ID ${peerId} responded with their favorite color! ${data}`);
+      })
+      // This useEffect hook will only run when the component is mounted. This 
+      // action is independent of state so we only need to set it up once.
+    }, [])
+
+    return <div>
+      <h1>What is your favorite color?</h1>
+      <input value={myFavoriteColor} onChange={handleChange}></input>
+      <button onClick={handleSend}>Send to Peers<button>
+    </div>
+  }
+
+  export default FavColorComponent
+```
+
 ## Audio and video
 
 Here's a simple example of how you could create an audio chatroom:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,7 +43,7 @@ declare module 'trystero' {
 
   export interface Room {
     getAction: <T>(
-      namespace: string,
+      namespace: string
     ) => [ActionSender<T>, ActionReceiver<T>, ActionProgress] | undefined
 
     makeAction: <T>(
@@ -99,7 +99,7 @@ declare module 'trystero' {
 
   export function joinRoom(
     config: BaseRoomConfig & TorrentRoomConfig,
-    roomId: string,
+    roomId: string
   ): Room
 
   export const selfId: string

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,8 +42,12 @@ declare module 'trystero' {
   }
 
   export interface Room {
+    getAction: <T>(
+      namespace: string,
+    ) => [ActionSender<T>, ActionReceiver<T>, ActionProgress] | undefined
+
     makeAction: <T>(
-      namespace: string
+      namespace: string,
     ) => [ActionSender<T>, ActionReceiver<T>, ActionProgress]
 
     ping: (id: string) => Promise<number>
@@ -95,7 +99,7 @@ declare module 'trystero' {
 
   export function joinRoom(
     config: BaseRoomConfig & TorrentRoomConfig,
-    roomId: string
+    roomId: string,
   ): Room
 
   export const selfId: string

--- a/src/room.js
+++ b/src/room.js
@@ -58,7 +58,11 @@ export default (onPeer, onSelfLeave) => {
     onPeerLeave(id)
   }
 
-  const makeAction = type => {
+  const getAction = type => {
+    return actions[type]
+  }
+
+  const makeAction = (type) => {
     if (!type) {
       throw mkErr('action type argument is required')
     }
@@ -78,7 +82,7 @@ export default (onPeer, onSelfLeave) => {
     const typePadded = decodeBytes(typeBytes)
 
     if (actions[typePadded]) {
-      throw mkErr(`action '${type}' already registered`)
+      return actions[typePadded]
     }
 
     let nonce = 0
@@ -309,6 +313,7 @@ export default (onPeer, onSelfLeave) => {
   getTrackMeta((meta, id) => (pendingTrackMetas[id] = meta))
 
   return {
+    getAction,
     makeAction,
 
     ping: async id => {

--- a/src/room.js
+++ b/src/room.js
@@ -82,7 +82,7 @@ export default (onPeer, onSelfLeave) => {
     const typePadded = decodeBytes(typeBytes)
 
     if (actions[typePadded]) {
-      return actions[typePadded]
+      return getAction(typePadded)
     }
 
     let nonce = 0

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ export const genId = n =>
 
 export const initGuard = (occupiedRooms, f) => (config, ns) => {
   if (occupiedRooms[ns]) {
-    return (_, _) => occupiedRooms[ns]
+    return (_, __) => occupiedRooms[ns]
   }
 
   if (!config) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ export const genId = n =>
 
 export const initGuard = (occupiedRooms, f) => (config, ns) => {
   if (occupiedRooms[ns]) {
-    throw mkErr(`already joined room ${ns}`)
+    return (_, _) => occupiedRooms[ns]
   }
 
   if (!config) {


### PR DESCRIPTION
Make `joinRoom` and `makeAction` idempotent and usable as React Hooks.

React components are generated and regenerated countless times as part of the [component lifecycle](https://react.dev/learn/lifecycle-of-reactive-effects#the-lifecycle-of-an-effect).

By making these functions idempotent instead of returning an error, we can make any React component multiplayer with very few lines of code. See the included 'favorite_color" example.

resolve #50 