### PR TITLE
Fix Firebase database URL behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,8 +724,9 @@ If you want to use the Firebase strategy and don't have an existing project:
 
 1. Create a [Firebase](https://firebase.google.com/) project
 1. Create a new Realtime Database
-1. Copy the database ID and use it as the `appId` in your Trystero
+1. Copy the Firebase Project ID and use it as the `appId` in your Trystero
    config
+1. Copy the Realtime Database reference URL (click the link icon at the top left of the page under the Realtime Database Data section) and use it as the `databaseURL` in your Trystero config
 1. [*Optional*] Configure the database with security rules to limit activity:
 
 ```json

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -5,6 +5,7 @@ declare module 'trystero/firebase' {
   export interface FirebaseRoomConfig {
     firebaseApp?: FirebaseApp
     rootPath?: string
+    databaseURL?: string
   }
 
   export function joinRoom(

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -37,6 +37,12 @@ const init = config => {
     return dbs[url] || (dbs[url] = getDatabase(config.firebaseApp))
   }
 
+  if(config.databaseURL) {
+    const url = config.databaseURL
+    return dbs[url] || (dbs[url] = getDatabase(initializeApp({databaseURL: url})))
+  }
+  
+  // these 2 lines dont work since depending on region, the URL will be https://APP_ID-default-rtdb{-OPTIONAL_REGION_NAME}.firebasedatabase.app
   const url = normalizeDbUrl(config.appId)
   return dbs[url] || (dbs[url] = getDatabase(initializeApp({databaseURL: url})))
 }


### PR DESCRIPTION
I was struggling to get the Firebase database to work, and it turns out its due to the fact that the `normalizeDbUrl()` function does not conform to actual database URLs, and cannot generate them correctly simply from the Firebase project ID.

The issue is that database URLs that are not in the US region take the form 
```
https://PROJECT_ID-default-rtdb{.SERVER_REGION}.firebasedatabase.app
```

While the US region database URLs take the form
```
https://PROJECT_ID-default-rtdb.firebaseio.com
```

In both cases the `normalizeDbUrl()` function does not generate a correct URL from just the project ID.

It seems the simplest solution is just add a `databaseURL` option to the config, and to just use that directly, which is what this pull request adds.

I kept the non-functional normalize function and the final 2 lines in `init()`, though they should not be used