### PR TITLE
Enhancement for Node.js and polyfills which are trickle-candidates not supported

### DIFF
--- a/src/peer.js
+++ b/src/peer.js
@@ -95,12 +95,9 @@ export default (initiator, {rtcConfig, rtcPolyfill, turnConfig}) => {
   }
 
   if (initiator) {
-    pc.setLocalDescription().then(() => {
-      handlers.signal?.({
-        type: pc.localDescription.type,
-        sdp: filterTrickle(pc.localDescription.sdp)
-      })
-    })
+    if (!pc.canTrickleIceCandidates) {
+      pc.onnegotiationneeded()
+    }
   }
 
   return {


### PR DESCRIPTION
This pull request includes updates to the `src/peer.js` file to enhance the handling of trickle ICE candidates. The changes ensure proper behaviour when trickle candidates are not supported.

Enhancements to trickle ICE candidate handling:

* Added a check to see if trickle ICE candidates are supported in the `checkState` function and updated the logic accordingly.
* Added a condition to trigger negotiation if the initiator does not support trickle ICE candidates.

If I have misunderstood something, please point it out to me. I would love to improve it. Thank you for the great library!