### PR TITLE
Add TurnConfig typings for proper joinRoom configuration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,6 +45,14 @@ declare module 'trystero' {
     relayRedundancy?: number
   }
 
+  export interface TurnConfig {
+    turnConfig?: {
+      urls: string | string[]
+      username?: string
+      credential?: string
+    }[]
+  }
+
   export interface Room {
     makeAction: <T extends DataPayload>(
       namespace: string
@@ -94,7 +102,7 @@ declare module 'trystero' {
   }
 
   export function joinRoom(
-    config: BaseRoomConfig & RelayConfig,
+    config: BaseRoomConfig & RelayConfig & TurnConfig,
     roomId: string
   ): Room
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,6 +50,7 @@ declare module 'trystero' {
       urls: string | string[]
       username?: string
       credential?: string
+      credentialType?: string
     }[]
   }
 


### PR DESCRIPTION
Created a new TurnConfig interface in the index.d.ts typing file to add missing supported keys