### PR TITLE
fix(closes #134): Enable peers to reconnect to rooms consistently

### DIFF
--- a/src/room.js
+++ b/src/room.js
@@ -63,6 +63,7 @@ export default (onPeer, onPeerLeave, onSelfLeave) => {
       return
     }
 
+    peerMap[id].destroy()
     delete peerMap[id]
     delete pendingTransmissions[id]
     delete pendingPongs[id]


### PR DESCRIPTION
For #134, this PR enables users to reconnect to rooms consistently. Without this fix, peers would get into variously broken states when they or another peer would leave a room and then rejoin it.

I've tested this within https://github.com/jeremyckahn/chitchatter and it seems to resolve the flakiness. When I get a chance, I will put together a preview environment of Chitchatter with this fix in place to demonstrate the improved behavior.