### PR TITLE
feat/RPC-style actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@supabase/supabase-js": "^2.93.3",
     "@waku/sdk": "^0.0.36",
     "firebase": "^12.8.0",
-    "mqtt": "^5.14.1"
+    "mqtt": "^5.14.1",
+    "msgpackr": "^1.11.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,34 @@ declare module 'trystero' {
 
   type DataPayload = JsonValue | Blob | ArrayBuffer | ArrayBufferView
 
+  type Rpc<T, R> = {
+    (peer: string, data: T): Promise<R>
+  }
+
+  type RpcPayload<T, R> =
+    | {
+        id: string
+        type: 'request'
+        payload: T
+      }
+    | {
+        id: string
+        type: 'response'
+        payload: R
+      }
+    | {
+        id: string
+        type: 'error'
+        error: string
+      }
+
+  type RpcDataPayload = DataPayload | Record<string, RpcDataPayload> | void
+
+  type MakeRpcOpts = {
+    timeout?: number
+    progress?: (p: number, peerId: string) => void
+  }
+
   type TargetPeers = string | string[] | null
 
   export interface BaseRoomConfig {
@@ -58,6 +86,12 @@ declare module 'trystero' {
     makeAction: <T extends DataPayload>(
       namespace: string
     ) => [ActionSender<T>, ActionReceiver<T>, ActionProgress]
+
+    makeRpc<T extends RpcDataPayload, R extends RpcDataPayload>(
+      name: string,
+      handler: (payload: T, peerId: string) => R | Promise<R>,
+      opt?: MakeRpcOpts
+    ): Rpc<T, R>
 
     ping: (id: string) => Promise<number>
 

--- a/src/room.js
+++ b/src/room.js
@@ -13,6 +13,7 @@ import {
   noOp,
   toJson
 } from './utils.js'
+import {pack, unpack} from 'msgpackr'
 
 const TypedArray = Object.getPrototypeOf(Uint8Array)
 const typeByteLimit = 12
@@ -29,6 +30,7 @@ const internalNs = ns => '@_' + ns
 export default (onPeer, onPeerLeave, onSelfLeave) => {
   const peerMap = {}
   const actions = {}
+  const rpcs = new Set()
   const actionsCache = {}
   const pendingTransmissions = {}
   const pendingPongs = {}
@@ -207,6 +209,107 @@ export default (onPeer, onPeerLeave, onSelfLeave) => {
     ])
   }
 
+  const makeRpc = (name, handler, opt = {}) => {
+    const timeout = opt.timeout ?? 10_000
+    if (rpcs.has(name)) {
+      throw mkErr(`Rpc with name (${name}) already defined`)
+    }
+
+    if (actions[name]) {
+      throw mkErr(`Action with name (${name}) already defined`)
+    }
+
+    rpcs.add(name)
+    const calls = new Map()
+
+    const [sendRpc, getRpc] = makeAction(name)
+
+    getRpc(async (data, peerId) => {
+      let decoded
+
+      try {
+        decoded = unpack(data)
+      } catch (err) {
+        console.error(
+          `RPC "${name}": failed to unpack message from ${peerId}:`,
+          err
+        )
+        return
+      }
+
+      if (
+        !decoded ||
+        !decoded.id ||
+        !['request', 'response', 'error'].includes(decoded.type)
+      ) {
+        console.error(
+          `RPC "${name}": malformed message from ${peerId}:`,
+          decoded
+        )
+        return
+      }
+
+      if (decoded.type === 'request') {
+        try {
+          const result = await handler(decoded.payload, peerId)
+
+          sendRpc(
+            pack({
+              id: decoded.id,
+              type: 'response',
+              payload: result
+            }),
+            peerId
+          )
+        } catch (e) {
+          sendRpc(
+            pack({
+              id: decoded.id,
+              type: 'error',
+              error: e.message || 'Unknown error occurred'
+            }),
+            peerId
+          )
+        }
+      } else {
+        const p = calls.get(decoded.id)
+        if (p) {
+          clearTimeout(p.timer)
+          if (decoded.type === 'error') {
+            p.promise.reject(new Error(decoded.error))
+          } else {
+            p.promise.resolve(decoded.payload)
+          }
+        }
+      }
+    })
+
+    return async (peerId, payload) => {
+      const id = crypto.randomUUID()
+      const packed = pack({id, type: 'request', payload})
+      sendRpc(packed, peerId, opt.progress)
+
+      const promise = Promise.withResolvers()
+      promise.promise.catch(() => {})
+      const timer = setTimeout(
+        () =>
+          promise.reject(
+            new Error(`RPC "${name}" timed out after ${opt.timeout}ms`)
+          ),
+        timeout
+      )
+
+      calls.set(id, {timer, promise})
+
+      try {
+        return await promise.promise
+      } finally {
+        calls.delete(id)
+        clearTimeout(timer)
+      }
+    }
+  }
+
   const handleData = (id, data) => {
     const buffer = new Uint8Array(data)
     const type = decodeBytes(buffer.subarray(typeIndex, nonceIndex)).replaceAll(
@@ -331,6 +434,7 @@ export default (onPeer, onPeerLeave, onSelfLeave) => {
 
   return {
     makeAction,
+    makeRpc,
 
     leave,
 


### PR DESCRIPTION
### Overview

This PR introduces `makeRpc`, a request/response abstraction built on top of the existing `makeAction` primitive. Until now the library only supported fire-and-forget messaging; there was no built-in way to send a message to a peer and await a response. `makeRpc` fills that gap by layering a lightweight call/response protocol on top of named actions.

### Example
Each RPC is registered under a unique name that is shared with actions. When a peer fires an RPC call, the following happen:
1. A unique id is generated for that call.
2. A timer is started to insure that calls to dead peers don't hang indefinitely.
3. The payload is encoded to bytes using `msgpackr` and sent to the receiving peer.
4. The receiving peer decodes the message back to an object, applies the `handler` to the payload received, re-encodes the result and sends it back to the caller. 
5. The caller resolves or rejects its pending promise based on the result it received (or didn't  receive).

here is a basic example of things work
```ts 
const room = joinRoom({ appId: "my-app-id" }, "my-room");

const rpc = room.makeRpc<number, string>(
  "intToStr",
  (n) => {
    // Do validation if needed
    console.log(`got payload: (${n}), converting to string`);
    return n.toString();
  },
  {
    timeout: 100, // <== 100ms timeout
    progress: (p) => console.log(`send progress: ${p}`),
  },
);

const str = await rpc(peerId, 12345); // <== this returns "12345" that was handled by peerId


```