### PR TITLE
Counter-announce to non-leader peers to speed up connectivity

### DIFF
--- a/packages/core/src/signal-handler.ts
+++ b/packages/core/src/signal-handler.ts
@@ -731,6 +731,10 @@ export const createSignalHandler =
       }
 
       if (!shouldLeadOffer && !announcePeerState.offerPeer) {
+        const peerSelfTopic = await sha1(topicPath(ctx.rootTopicPlaintext, peerId));
+        if (!ctx.isLeaving() && !announcePeerState.connectedPeer) {
+          signalPeer(peerSelfTopic, toJson({peerId: selfId}))
+        }
         return
       }
 

--- a/test/node/shared-room-peer-reuse.spec.ts
+++ b/test/node/shared-room-peer-reuse.spec.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {encrypt, genKey} from '../../packages/core/src/crypto.ts'
 import createStrategy from '../../packages/core/src/strategy.ts'
+import {selfId} from '../../packages/core/src/utils.ts'
 
 type Subscriber = {
   rootTopic: string
@@ -347,6 +348,111 @@ void test(
     } finally {
       await appARoom.leave().catch(() => {})
       await appBRoom.leave().catch(() => {})
+    }
+  }
+)
+
+void test(
+  'higher-ID peer replies with own announcement to lower-ID peer selfTopic',
+  {timeout: 5_000},
+  async () => {
+    const subscribers: Subscriber[] = []
+    const appId = `reply-announce-${Date.now()}`
+    const lowerPeerId =
+      String.fromCharCode(selfId.charCodeAt(0) - 1) + selfId.slice(1)
+
+    const joinRoom = createStrategy({
+      init: () => ({}),
+      subscribe: async (_relay, rootTopic, selfTopic, onMessage) => {
+        subscribers.push({rootTopic, selfTopic, onMessage})
+        return () => {}
+      },
+      announce: () => {}
+    })
+
+    const room = joinRoom(
+      {appId, rtcPolyfill: MockRTCPeerConnection},
+      'reply-room'
+    )
+
+    try {
+      await waitFor(() => subscribers.length >= 1)
+      const sub = subscribers[0]
+
+      const signalCalls: {topic: string; signal: string}[] = []
+
+      await sub.onMessage(
+        sub.rootTopic,
+        {peerId: lowerPeerId},
+        (topic, signal) => signalCalls.push({topic, signal})
+      )
+
+      await wait(50)
+
+      assert.equal(signalCalls.length, 1, 'should reply to lower-ID peer')
+
+      const payload = JSON.parse(signalCalls[0].signal)
+      assert.equal(payload.peerId, selfId, 'reply should contain our peerId')
+      assert.ok(
+        !payload.offer && !payload.answer && !payload.candidate,
+        'reply should only contain peerId, not SDP fields.'
+      )
+    } finally {
+      await room.leave().catch(() => {})
+    }
+  }
+)
+
+void test(
+  'lower-ID peer does not reply to announcement from higher-ID peer',
+  {timeout: 5_000},
+  async () => {
+    const subscribers: Subscriber[] = []
+    const appId = `no-reply-${Date.now()}`
+    const higherPeerId =
+      String.fromCharCode(selfId.charCodeAt(0) + 1) + selfId.slice(1)
+
+    const joinRoom = createStrategy({
+      init: () => ({}),
+      subscribe: async (_relay, rootTopic, selfTopic, onMessage) => {
+        subscribers.push({rootTopic, selfTopic, onMessage})
+        return () => {}
+      },
+      announce: () => {}
+    })
+
+    const room = joinRoom(
+      {appId, rtcPolyfill: MockRTCPeerConnection},
+      'no-reply-room'
+    )
+
+    try {
+      await waitFor(() => subscribers.length >= 1)
+      const sub = subscribers[0]
+
+      const replyCalls: string[] = []
+
+      await sub.onMessage(
+        sub.rootTopic,
+        {peerId: higherPeerId},
+        (_topic, signal) => {
+          const parsed = JSON.parse(signal)
+
+          if (!parsed.offer && !parsed.answer && !parsed.candidate) {
+            replyCalls.push(signal)
+          }
+        }
+      )
+
+      await wait(50)
+
+      assert.equal(
+        replyCalls.length,
+        0,
+        'lower-ID peer should not reply.'
+      )
+    } finally {
+      await room.leave().catch(() => {})
     }
   }
 )


### PR DESCRIPTION
### Faster discovery by counter-announcing

To prevent race conditions when exchanging WebRTC SDP offers, we compare peer IDs. The lower-ID peer always leads by creating the offer.

```
const shouldLeadOffer = selfId < peerId

...

if (!shouldLeadOffer && !announcePeerState.offerPeer) {
  return
}
```

This means that when a new lower ID peer joins and announces, the higher ID peer silently ignores. The new joining peer must then wait up to ~5.3 seconds for the higher ID peer's next re-announce before a negotiation for connectivity begins.

This change makes the higher ID peer immediately counter-announce to the lower ID peer's self topic, allowing the connection to begin right away.

### Changes
- packages/core/src/signal-handler.ts — In the !shouldLeadOffer branch, reply with {peerId: selfId} to the announcing peer's self topic instead of returning silently.
- test/node/shared-room-peer-reuse.spec.ts — Two new test cases: higher-ID peer replies to lower-ID peer; lower-ID peer does not reply (it leads the offer instead).
