### PR TITLE
Relay reconnect resilience: REQ resubscribe, announce supervision, backoff cap

### DIFF
--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -21,6 +21,7 @@ import {
   noOp,
   resetTimer,
   selfId,
+  toErrorMessage,
   topicPath,
   values,
   watchOnline
@@ -458,6 +459,7 @@ export default <TRelay, TConfig extends BaseRoomConfig = JoinRoomConfig>({
 
     ctx.announceIntervals = initPromises.map(() => announceIntervalMs)
     const announceAttemptCounts = initPromises.map(() => 0)
+    const announceErrorStreaks = initPromises.map(() => 0)
     const announceTimeouts: Array<ReturnType<typeof setTimeout> | undefined> =
       []
 
@@ -487,13 +489,31 @@ export default <TRelay, TConfig extends BaseRoomConfig = JoinRoomConfig>({
         }
 
         const extra = isPassive ? {passive: true} : undefined
-        const ms = await announce(
-          relay,
-          rootTopic,
-          selfTopic,
-          extra,
-          strategyContext
-        )
+        let ms: number | void = undefined
+
+        try {
+          ms = await announce(
+            relay,
+            rootTopic,
+            selfTopic,
+            extra,
+            strategyContext
+          )
+          announceErrorStreaks[i] = 0
+        } catch (error) {
+          const errorStreak = announceErrorStreaks[i] ?? 0
+
+          if (errorStreak === 0) {
+            onJoinError?.({
+              error: toErrorMessage(error, 'announce failed'),
+              appId,
+              peerId: selfId,
+              roomId
+            })
+          }
+
+          announceErrorStreaks[i] = errorStreak + 1
+        }
 
         if (didLeaveRoom || (isPassive && !ctx.isActive)) {
           return

--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -504,12 +504,9 @@ export default <TRelay, TConfig extends BaseRoomConfig = JoinRoomConfig>({
           const errorStreak = announceErrorStreaks[i] ?? 0
 
           if (errorStreak === 0) {
-            onJoinError?.({
-              error: toErrorMessage(error, 'announce failed'),
-              appId,
-              peerId: selfId,
-              roomId
-            })
+            console.warn(
+              `${libName}: announce failed - ${toErrorMessage(error, '')}`
+            )
           }
 
           announceErrorStreaks[i] = errorStreak + 1

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import type {BaseRoomConfig, RelayConfig, SocketClient} from './types'
 
-const {floor, min, random, sin} = Math
+const {floor, min, sin} = Math
 
 export const libName = 'Trystero'
 
@@ -10,7 +10,7 @@ export const alloc = <T>(n: number, f: (v: undefined, i: number) => T): T[] =>
 const charSet = '0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz'
 
 export const genId = (n: number): string =>
-  alloc(n, () => charSet[floor(random() * charSet.length)] ?? '').join('')
+  alloc(n, () => charSet[floor(Math.random() * charSet.length)] ?? '').join('')
 
 export const selfId = genId(20)
 
@@ -139,38 +139,40 @@ export const makeSocket = (
   onReconnect?: () => void
 ): SocketClient => {
   const client = {} as SocketClient
-  let isReconnect = false
+  let didOpen = false
+  let resolveReady: (_: SocketClient) => void = noOp
+
+  client.ready = new Promise(res => (resolveReady = res))
 
   const init = (): void => {
     const socket = new WebSocket(url)
 
     socket.onclose = () => {
-      isReconnect = true
-
       if (reconnectionLockingPromise) {
         void reconnectionLockingPromise.then(init)
         return
       }
 
       const period = (socketRetryPeriods[url] ??= defaultRetryMs)
-      setTimeout(init, random() * period)
+      setTimeout(init, Math.random() * period)
       socketRetryPeriods[url] = min(period * 2, maxRetryMs)
     }
 
     socket.onmessage = e => onMessage(String(e.data))
     client.socket = socket
     client.url = socket.url
-    client.ready = new Promise<SocketClient>(
-      res =>
-        (socket.onopen = () => {
-          res(client)
-          socketRetryPeriods[url] = defaultRetryMs
 
-          if (isReconnect) {
-            onReconnect?.()
-          }
-        })
-    )
+    socket.onopen = () => {
+      const isReconnect = didOpen
+
+      didOpen = true
+      resolveReady(client)
+      socketRetryPeriods[url] = defaultRetryMs
+
+      if (isReconnect) {
+        onReconnect?.()
+      }
+    }
 
     client.send = data => {
       if (socket.readyState === 1) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -135,14 +135,18 @@ export const resumeRelayReconnection = (): void => {
 
 export const makeSocket = (
   url: string,
-  onMessage: (data: string) => void
+  onMessage: (data: string) => void,
+  onReconnect?: () => void
 ): SocketClient => {
   const client = {} as SocketClient
+  let isReconnect = false
 
   const init = (): void => {
     const socket = new WebSocket(url)
 
     socket.onclose = () => {
+      isReconnect = true
+
       if (reconnectionLockingPromise) {
         void reconnectionLockingPromise.then(init)
         return
@@ -161,6 +165,10 @@ export const makeSocket = (
         (socket.onopen = () => {
           res(client)
           socketRetryPeriods[url] = defaultRetryMs
+
+          if (isReconnect) {
+            onReconnect?.()
+          }
         })
     )
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import type {BaseRoomConfig, RelayConfig, SocketClient} from './types'
 
-const {floor, random, sin} = Math
+const {floor, min, random, sin} = Math
 
 export const libName = 'Trystero'
 
@@ -112,6 +112,7 @@ export const strToNum = (
 ): number => str.split('').reduce((a, c) => a + c.charCodeAt(0), 0) % limit
 
 const defaultRetryMs = 3333
+const maxRetryMs = 60_000
 const socketRetryPeriods: Record<string, number> = {}
 
 let reconnectionLockingPromise: Promise<void> | null = null
@@ -147,9 +148,9 @@ export const makeSocket = (
         return
       }
 
-      socketRetryPeriods[url] ??= defaultRetryMs
-      setTimeout(init, socketRetryPeriods[url])
-      socketRetryPeriods[url] *= 2
+      const period = (socketRetryPeriods[url] ??= defaultRetryMs)
+      setTimeout(init, random() * period)
+      socketRetryPeriods[url] = min(period * 2, maxRetryMs)
     }
 
     socket.onmessage = e => onMessage(String(e.data))

--- a/packages/nostr/src/index.ts
+++ b/packages/nostr/src/index.ts
@@ -189,54 +189,70 @@ const flushBatch = (client: SocketClient): void => {
   })
 }
 
+const resubscribeOnReconnect = (client: SocketClient): void => {
+  const batcher = batchers[client.url]
+
+  if (batcher && batcher.topics.size > 0) {
+    flushBatch(client)
+  }
+}
+
 export const joinRoom: JoinRoom<NostrRoomConfig> = createTopicStrategy({
   init: config =>
     getRelays(config, defaultRelayUrls, defaultRedundancy, true).map(url => {
       const client = relayManager.register(
         url,
-        makeSocket(url, data => {
-          const [msgType, subId, payload, relayMsg] =
-            fromJson<
-              [
-                string,
-                string,
-                {content: string; tags?: string[][]} | boolean,
-                string
-              ]
-            >(data)
+        makeSocket(
+          url,
+          data => {
+            const [msgType, subId, payload, relayMsg] =
+              fromJson<
+                [
+                  string,
+                  string,
+                  {content: string; tags?: string[][]} | boolean,
+                  string
+                ]
+              >(data)
 
-          if (msgType !== eventMsgType) {
-            const prefix = `${libName}: relay failure from ${client.url} - `
+            if (msgType !== eventMsgType) {
+              const prefix = `${libName}: relay failure from ${client.url} - `
 
-            if (msgType === 'NOTICE') {
-              console.warn(prefix + subId)
-            } else if (msgType === 'OK' && !payload) {
-              console.warn(prefix + relayMsg)
-            }
+              if (msgType === 'NOTICE') {
+                console.warn(prefix + subId)
+              } else if (msgType === 'OK' && !payload) {
+                console.warn(prefix + relayMsg)
+              }
 
-            return
-          }
-
-          if (payload && typeof payload === 'object' && 'content' in payload) {
-            const {content} = payload
-            const handler = msgHandlers[subId]
-
-            if (handler) {
-              handler(subIdToTopic[subId] ?? '', content)
               return
             }
 
-            const batcher = batchers[client.url]
+            if (
+              payload &&
+              typeof payload === 'object' &&
+              'content' in payload
+            ) {
+              const {content} = payload
+              const handler = msgHandlers[subId]
 
-            if (batcher?.subIds.includes(subId) && payload.tags) {
-              const topicTag = payload.tags.find(t => t[0] === tag)
+              if (handler) {
+                handler(subIdToTopic[subId] ?? '', content)
+                return
+              }
 
-              if (topicTag?.[1]) {
-                batcher.topics.get(topicTag[1])?.(topicTag[1], content)
+              const batcher = batchers[client.url]
+
+              if (batcher?.subIds.includes(subId) && payload.tags) {
+                const topicTag = payload.tags.find(t => t[0] === tag)
+
+                if (topicTag?.[1]) {
+                  batcher.topics.get(topicTag[1])?.(topicTag[1], content)
+                }
               }
             }
-          }
-        })
+          },
+          () => resubscribeOnReconnect(client)
+        )
       )
 
       return client.ready

--- a/test/node/announce-supervision.spec.ts
+++ b/test/node/announce-supervision.spec.ts
@@ -85,6 +85,9 @@ void test(
   {timeout: 5_000},
   async () => {
     let announceCount = 0
+    const joinErrors = []
+    const warnings = []
+    const realWarn = console.warn
 
     // Without the fix, queueAnnounce throws an unhandled rejection that
     // node:test would catch first. Swallow it so the assertion runs.
@@ -96,6 +99,7 @@ void test(
 
       return realEmit(event, ...args)
     }
+    console.warn = (...args) => warnings.push(args)
 
     const joinRoom = createStrategy({
       init: () => ({}),
@@ -127,7 +131,14 @@ void test(
         announceCount >= 2,
         `expected the announce loop to keep firing after a rejection, but it stopped after ${announceCount} call(s)`
       )
+
+      assert.equal(
+        warnings.length,
+        1,
+        'first announce failure in a streak should be logged once'
+      )
     } finally {
+      console.warn = realWarn
       process.emit = realEmit
       await room.leave()
     }

--- a/test/node/announce-supervision.spec.ts
+++ b/test/node/announce-supervision.spec.ts
@@ -1,0 +1,135 @@
+// @ts-nocheck
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import createStrategy from '../../packages/core/src/strategy.ts'
+
+class MockDataChannel {
+  readyState = 'connecting'
+  binaryType = 'arraybuffer'
+  bufferedAmountLowThreshold = 0
+  onmessage = null
+  onopen = null
+  onclose = null
+  onerror = null
+
+  close() {
+    this.readyState = 'closed'
+    this.onclose?.()
+  }
+
+  send() {}
+}
+
+class MockRTCPeerConnection {
+  iceGatheringState = 'complete'
+  connectionState = 'new'
+  iceConnectionState = 'new'
+  signalingState = 'stable'
+  localDescription = null
+  onconnectionstatechange = null
+  listeners = {}
+
+  createDataChannel() {
+    return new MockDataChannel()
+  }
+
+  addEventListener(event, fn) {
+    ;(this.listeners[event] ??= new Set()).add(fn)
+  }
+
+  removeEventListener(event, fn) {
+    this.listeners[event]?.delete(fn)
+  }
+
+  restartIce() {}
+
+  async createOffer() {
+    return {type: 'offer', sdp: `mock-offer-${Math.random()}`}
+  }
+
+  async setLocalDescription(description) {
+    if (description?.type === 'rollback') {
+      this.signalingState = 'stable'
+      return
+    }
+
+    const next = description ?? (await this.createOffer())
+    this.localDescription = next
+    this.signalingState = next.type === 'offer' ? 'have-local-offer' : 'stable'
+    this.listeners['icegatheringstatechange']?.forEach(fn => fn())
+  }
+
+  async setRemoteDescription() {
+    this.signalingState = 'stable'
+  }
+
+  close() {
+    this.connectionState = 'closed'
+    this.iceConnectionState = 'closed'
+    this.onconnectionstatechange?.()
+  }
+
+  getSenders() {
+    return []
+  }
+
+  addTrack() {
+    return {}
+  }
+
+  removeTrack() {}
+}
+
+void test(
+  'Trystero: announce loop continues after a single announce rejection',
+  {timeout: 5_000},
+  async () => {
+    let announceCount = 0
+
+    // Without the fix, queueAnnounce throws an unhandled rejection that
+    // node:test would catch first. Swallow it so the assertion runs.
+    const realEmit = process.emit.bind(process)
+    process.emit = (event, ...args) => {
+      if (event === 'unhandledRejection') {
+        return true
+      }
+
+      return realEmit(event, ...args)
+    }
+
+    const joinRoom = createStrategy({
+      init: () => ({}),
+      subscribe: () => () => {},
+      announce: () => {
+        announceCount += 1
+
+        if (announceCount === 1) {
+          return Promise.reject(new Error('simulated announce failure'))
+        }
+
+        return undefined
+      }
+    })
+
+    const room = joinRoom(
+      {
+        appId: `trystero-announce-supervision-${Date.now()}-${Math.random()}`,
+        password: 'announce-supervision-test',
+        rtcPolyfill: MockRTCPeerConnection
+      },
+      'r'
+    )
+
+    try {
+      await new Promise(res => setTimeout(res, 800))
+
+      assert.ok(
+        announceCount >= 2,
+        `expected the announce loop to keep firing after a rejection, but it stopped after ${announceCount} call(s)`
+      )
+    } finally {
+      process.emit = realEmit
+      await room.leave()
+    }
+  }
+)

--- a/test/node/nostr-resubscribe.spec.ts
+++ b/test/node/nostr-resubscribe.spec.ts
@@ -1,0 +1,224 @@
+// @ts-nocheck
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {joinRoom} from '../../packages/nostr/src/index.ts'
+
+class MockDataChannel {
+  readyState = 'connecting'
+  binaryType = 'arraybuffer'
+  bufferedAmountLowThreshold = 0
+  onmessage = null
+  onopen = null
+  onclose = null
+  onerror = null
+
+  close() {
+    this.readyState = 'closed'
+    this.onclose?.()
+  }
+
+  send() {}
+}
+
+class MockRTCPeerConnection {
+  iceGatheringState = 'complete'
+  connectionState = 'new'
+  iceConnectionState = 'new'
+  signalingState = 'stable'
+  localDescription = null
+  onconnectionstatechange = null
+  listeners = {}
+
+  createDataChannel() {
+    return new MockDataChannel()
+  }
+
+  addEventListener(event, fn) {
+    ;(this.listeners[event] ??= new Set()).add(fn)
+  }
+
+  removeEventListener(event, fn) {
+    this.listeners[event]?.delete(fn)
+  }
+
+  restartIce() {}
+
+  async createOffer() {
+    return {type: 'offer', sdp: `mock-offer-${Math.random()}`}
+  }
+
+  async setLocalDescription(description) {
+    if (description?.type === 'rollback') {
+      this.signalingState = 'stable'
+      return
+    }
+
+    const next = description ?? (await this.createOffer())
+    this.localDescription = next
+    this.signalingState = next.type === 'offer' ? 'have-local-offer' : 'stable'
+    this.listeners['icegatheringstatechange']?.forEach(fn => fn())
+  }
+
+  async setRemoteDescription() {
+    this.signalingState = 'stable'
+  }
+
+  close() {
+    this.connectionState = 'closed'
+    this.iceConnectionState = 'closed'
+    this.onconnectionstatechange?.()
+  }
+
+  getSenders() {
+    return []
+  }
+
+  addTrack() {
+    return {}
+  }
+
+  removeTrack() {}
+}
+
+void test(
+  'Trystero/nostr: REQ frames are re-sent when the relay socket reconnects',
+  {timeout: 10_000},
+  async () => {
+    const realWebSocket = globalThis.WebSocket
+    const realSetTimeout = globalThis.setTimeout
+    const tick = (ms = 0) => new Promise(res => realSetTimeout(res, ms))
+
+    const sockets = []
+    let allowClose = true
+    const stubbedTimers = []
+
+    class ControlledSocket {
+      url = ''
+      readyState = 0
+      onopen = null
+      onclose = null
+      onmessage = null
+      sent = []
+
+      constructor(url) {
+        this.url = url
+        sockets.push(this)
+      }
+
+      open() {
+        this.readyState = 1
+        this.onopen?.()
+      }
+
+      triggerClose() {
+        if (!allowClose) {
+          return
+        }
+
+        this.readyState = 3
+        this.onclose?.()
+      }
+
+      send(data) {
+        this.sent.push(data)
+      }
+
+      close() {
+        this.triggerClose()
+      }
+    }
+
+    // makeSocket has no injection seam for WebSocket or its retry timer; the
+    // setTimeout shim queues every timer so the jittered reconnect and batched
+    // flushBatch (scheduled with setTimeout(0)) can be fired on demand.
+    globalThis.WebSocket = ControlledSocket
+    globalThis.setTimeout = fn => {
+      stubbedTimers.push(fn)
+      return stubbedTimers.length - 1
+    }
+
+    const drainTimers = (limit = 100) => {
+      let count = 0
+
+      while (stubbedTimers.length > 0 && count < limit) {
+        const fn = stubbedTimers.shift()
+
+        try {
+          fn?.()
+        } catch {
+          // ignore — announce loops may throw without a real relay
+        }
+
+        count += 1
+      }
+    }
+
+    const isReqFrame = frame =>
+      typeof frame === 'string' && frame.startsWith('["REQ"')
+
+    let room
+    try {
+      room = joinRoom(
+        {
+          appId: `trystero-nostr-resubscribe-${Date.now()}`,
+          password: 'resubscribe-test',
+          relayConfig: {urls: [`ws://test-nostr-${Date.now()}`], redundancy: 1},
+          rtcPolyfill: MockRTCPeerConnection
+        },
+        'r'
+      )
+
+      await tick(0)
+      assert.equal(sockets.length, 1, 'expected one socket to be created')
+
+      const first = sockets[0]
+      first.open()
+      // Let the subscribe chain resolve and queue the batched flushBatch.
+      await tick(50)
+      drainTimers()
+      await tick(50)
+
+      const reqOnFirst = first.sent.filter(isReqFrame)
+      assert.ok(
+        reqOnFirst.length >= 1,
+        `expected at least one batched REQ frame on initial socket, got ${reqOnFirst.length}`
+      )
+
+      first.triggerClose()
+      await tick(0)
+
+      assert.ok(
+        stubbedTimers.length > 0,
+        'expected a reconnect to be scheduled after the socket closed'
+      )
+      drainTimers()
+      await tick(50)
+
+      assert.equal(
+        sockets.length,
+        2,
+        'expected the retry to create a new socket'
+      )
+
+      const second = sockets[1]
+      second.open()
+      await tick(50)
+      drainTimers()
+      await tick(50)
+
+      const reqOnSecond = second.sent.filter(isReqFrame)
+      assert.ok(
+        reqOnSecond.length >= 1,
+        `BUG: expected at least one batched REQ frame to be re-sent on reconnect, but got ${reqOnSecond.length}`
+      )
+    } finally {
+      allowClose = false
+      globalThis.WebSocket = realWebSocket
+      globalThis.setTimeout = realSetTimeout
+
+      if (room) {
+        await room.leave()
+      }
+    }
+  }
+)

--- a/test/node/relay-reconnect-regression.spec.ts
+++ b/test/node/relay-reconnect-regression.spec.ts
@@ -1,0 +1,283 @@
+// @ts-nocheck
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import createStrategy from '../../packages/core/src/strategy.ts'
+import {makeSocket} from '../../packages/core/src/utils.ts'
+import {joinRoom} from '../../packages/nostr/src/index.ts'
+
+class MockDataChannel {
+  readyState = 'connecting'
+  binaryType = 'arraybuffer'
+  bufferedAmountLowThreshold = 0
+  onmessage = null
+  onopen = null
+  onclose = null
+  onerror = null
+
+  close() {
+    this.readyState = 'closed'
+    this.onclose?.()
+  }
+
+  send() {}
+}
+
+class MockRTCPeerConnection {
+  iceGatheringState = 'complete'
+  connectionState = 'new'
+  iceConnectionState = 'new'
+  signalingState = 'stable'
+  localDescription = null
+  onnegotiationneeded = null
+  onconnectionstatechange = null
+  ontrack = null
+  ondatachannel = null
+  listeners = {}
+
+  createDataChannel() {
+    return new MockDataChannel()
+  }
+
+  addEventListener(event, fn) {
+    ;(this.listeners[event] ??= new Set()).add(fn)
+  }
+
+  removeEventListener(event, fn) {
+    this.listeners[event]?.delete(fn)
+  }
+
+  restartIce() {}
+
+  async createOffer() {
+    return {type: 'offer', sdp: `mock-offer-${Math.random()}`}
+  }
+
+  async setLocalDescription(description) {
+    const nextDescription = description ?? (await this.createOffer())
+    this.localDescription = nextDescription
+    this.signalingState =
+      nextDescription.type === 'offer' ? 'have-local-offer' : 'stable'
+    this.listeners['icegatheringstatechange']?.forEach(listener => listener())
+  }
+
+  async setRemoteDescription() {
+    this.signalingState = 'stable'
+  }
+
+  close() {
+    this.connectionState = 'closed'
+    this.iceConnectionState = 'closed'
+    this.onconnectionstatechange?.()
+  }
+
+  getSenders() {
+    return []
+  }
+
+  addTrack() {
+    return {}
+  }
+
+  removeTrack() {}
+}
+
+class AutoOpenWebSocket {
+  static sockets = []
+
+  readyState = 0
+  sent = []
+  onopen = null
+  onclose = null
+  onmessage = null
+  url
+
+  constructor(url) {
+    this.url = url
+    AutoOpenWebSocket.sockets.push(this)
+
+    setTimeout(() => {
+      this.readyState = 1
+      this.onopen?.()
+    }, 0)
+  }
+
+  send(data) {
+    this.sent.push(JSON.parse(data))
+  }
+
+  close() {
+    this.readyState = 3
+    this.onclose?.()
+  }
+}
+
+class ManualWebSocket {
+  static sockets = []
+
+  readyState = 0
+  sent = []
+  onopen = null
+  onclose = null
+  onmessage = null
+  url
+
+  constructor(url) {
+    this.url = url
+    ManualWebSocket.sockets.push(this)
+  }
+
+  send(data) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = 3
+    this.onclose?.()
+  }
+}
+
+const wait = (ms: number) => new Promise(res => setTimeout(res, ms))
+
+const waitFor = async (
+  check: () => boolean,
+  timeoutMs = 2_000
+): Promise<void> => {
+  const start = Date.now()
+
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition')
+    }
+
+    await wait(10)
+  }
+}
+
+void test(
+  'Trystero: nostr re-sends batched subscriptions after relay socket reconnect',
+  {timeout: 10_000},
+  async () => {
+    const originalWebSocket = globalThis.WebSocket
+
+    globalThis.WebSocket = AutoOpenWebSocket
+    AutoOpenWebSocket.sockets.length = 0
+
+    const room = joinRoom(
+      {
+        appId: `nostr-resubscribe-${Date.now()}`,
+        passive: true,
+        relayConfig: {urls: ['wss://nostr-resubscribe.test']}
+      },
+      'room'
+    )
+
+    try {
+      await waitFor(() =>
+        AutoOpenWebSocket.sockets[0]?.sent.some(msg => msg[0] === 'REQ')
+      )
+
+      const firstSocket = AutoOpenWebSocket.sockets[0]
+      firstSocket.close()
+
+      await waitFor(() => AutoOpenWebSocket.sockets.length >= 2, 5_000)
+      await wait(50)
+
+      const secondSocket = AutoOpenWebSocket.sockets[1]
+      const resentReqs = secondSocket.sent.filter(msg => msg[0] === 'REQ')
+
+      assert.ok(
+        resentReqs.length >= 1,
+        'reconnected nostr socket should receive the existing batched REQ'
+      )
+    } finally {
+      await room.leave().catch(() => {})
+      globalThis.WebSocket = originalWebSocket
+    }
+  }
+)
+
+void test(
+  'Trystero: relay announcements keep retrying after a rejected announce',
+  {timeout: 10_000},
+  async () => {
+    const unhandledRejections = []
+    const onUnhandledRejection = reason => {
+      unhandledRejections.push(reason)
+    }
+
+    process.prependListener('unhandledRejection', onUnhandledRejection)
+
+    let announceCalls = 0
+    const joinRoom = createStrategy({
+      init: () => ({}),
+      subscribe: () => () => {},
+      announce: async () => {
+        announceCalls++
+
+        if (announceCalls === 1) {
+          throw new Error('transient announce failure')
+        }
+      }
+    })
+
+    const room = joinRoom(
+      {
+        appId: `announce-supervision-${Date.now()}`,
+        rtcPolyfill: MockRTCPeerConnection
+      },
+      'room'
+    )
+
+    try {
+      await waitFor(() => announceCalls >= 2, 1_000)
+      assert.equal(
+        unhandledRejections.length,
+        0,
+        'announce rejection should be supervised instead of escaping'
+      )
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+      await room.leave().catch(() => {})
+    }
+  }
+)
+
+void test(
+  'Trystero: socket reconnect backoff stays capped',
+  {timeout: 10_000},
+  async () => {
+    const originalWebSocket = globalThis.WebSocket
+    const originalSetTimeout = globalThis.setTimeout
+    const retryDelays = []
+
+    globalThis.WebSocket = ManualWebSocket
+    ManualWebSocket.sockets.length = 0
+    globalThis.setTimeout = (fn, ms, ...args) => {
+      retryDelays.push(ms)
+
+      return originalSetTimeout(fn, 0, ...args)
+    }
+
+    try {
+      const client = makeSocket('wss://socket-backoff.test', () => {})
+
+      for (let i = 0; i < 16; i++) {
+        const socket = ManualWebSocket.sockets.at(-1)
+        socket.close()
+
+        await waitFor(() => ManualWebSocket.sockets.length === i + 2)
+      }
+
+      assert.ok(client.socket)
+      assert.ok(
+        Math.max(...retryDelays) <= 60_000,
+        `expected retry delay to stay capped at 60000ms, got ${Math.max(
+          ...retryDelays
+        )}ms`
+      )
+    } finally {
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.WebSocket = originalWebSocket
+    }
+  }
+)

--- a/test/node/socket-backoff.spec.ts
+++ b/test/node/socket-backoff.spec.ts
@@ -9,6 +9,7 @@ void test(
   'Trystero: socket reconnect backoff is capped at a sane maximum',
   {timeout: 5_000},
   async () => {
+    const realRandom = Math.random
     const realSetTimeout = globalThis.setTimeout
     const realWebSocket = globalThis.WebSocket
 
@@ -38,6 +39,7 @@ void test(
 
     try {
       // makeSocket has no injection seam for WebSocket or its retry timer.
+      Math.random = () => 1
       globalThis.setTimeout = (fn, delay) => {
         scheduledDelays.push(delay)
         pendingInit = fn
@@ -66,6 +68,82 @@ void test(
       )
     } finally {
       allowClose = false
+      Math.random = realRandom
+      globalThis.setTimeout = realSetTimeout
+      globalThis.WebSocket = realWebSocket
+    }
+  }
+)
+
+void test(
+  'Trystero: socket ready resolves after pre-open reconnect succeeds',
+  {timeout: 5_000},
+  async () => {
+    const realSetTimeout = globalThis.setTimeout
+    const realWebSocket = globalThis.WebSocket
+
+    const sockets = []
+    let pendingInit = null
+
+    class ControlledSocket {
+      url = ''
+      readyState = 0
+      onclose = null
+      onopen = null
+      onmessage = null
+
+      constructor(url) {
+        this.url = url
+        sockets.push(this)
+      }
+
+      send() {}
+
+      open() {
+        this.readyState = 1
+        this.onopen?.()
+      }
+
+      close() {
+        this.readyState = 3
+        this.onclose?.()
+      }
+    }
+
+    try {
+      globalThis.setTimeout = fn => {
+        pendingInit = fn
+        return 0
+      }
+      globalThis.WebSocket = ControlledSocket
+
+      const client = makeSocket(`ws://test-ready-${Date.now()}`, () => {})
+      const firstReady = client.ready
+
+      sockets[0].close()
+      assert.ok(pendingInit, 'expected retry to be scheduled')
+
+      const retry = pendingInit
+      pendingInit = null
+      retry()
+      sockets[1].open()
+
+      const readyClient = await Promise.race([
+        firstReady,
+        new Promise(res => realSetTimeout(() => res(null), 50))
+      ])
+
+      assert.equal(
+        readyClient,
+        client,
+        'original ready promise should resolve when a retry opens'
+      )
+      assert.equal(
+        firstReady,
+        client.ready,
+        'makeSocket should keep a stable ready promise across retries'
+      )
+    } finally {
       globalThis.setTimeout = realSetTimeout
       globalThis.WebSocket = realWebSocket
     }

--- a/test/node/socket-backoff.spec.ts
+++ b/test/node/socket-backoff.spec.ts
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {makeSocket} from '../../packages/core/src/utils.ts'
+
+const tick = () => Promise.resolve()
+
+void test(
+  'Trystero: socket reconnect backoff is capped at a sane maximum',
+  {timeout: 5_000},
+  async () => {
+    const realSetTimeout = globalThis.setTimeout
+    const realWebSocket = globalThis.WebSocket
+
+    const scheduledDelays = []
+    let pendingInit = null
+    let allowClose = true
+
+    class FailingSocket {
+      url = ''
+      readyState = 0
+      onclose = null
+      onopen = null
+      onmessage = null
+
+      constructor(url) {
+        this.url = url
+        queueMicrotask(() => {
+          if (allowClose) {
+            this.onclose?.()
+          }
+        })
+      }
+
+      send() {}
+      close() {}
+    }
+
+    try {
+      // makeSocket has no injection seam for WebSocket or its retry timer.
+      globalThis.setTimeout = (fn, delay) => {
+        scheduledDelays.push(delay)
+        pendingInit = fn
+        return 0
+      }
+      globalThis.WebSocket = FailingSocket
+
+      makeSocket(`ws://test-backoff-${Date.now()}`, () => {})
+
+      for (let i = 0; i < 15; i += 1) {
+        await tick()
+        assert.ok(
+          pendingInit,
+          `expected a retry to be scheduled after attempt ${i + 1}`
+        )
+
+        const next = pendingInit
+        pendingInit = null
+        next()
+      }
+
+      const maxDelay = Math.max(...scheduledDelays)
+      assert.ok(
+        maxDelay <= 60_000,
+        `expected reconnect delay to be capped at 60s, but max was ${maxDelay}ms`
+      )
+    } finally {
+      allowClose = false
+      globalThis.setTimeout = realSetTimeout
+      globalThis.WebSocket = realWebSocket
+    }
+  }
+)


### PR DESCRIPTION
** DISCLAIMER: This is heavily aided by Claude, so I am accepting this might be rejected outright **

I hit these three bugs when building an Android Chrome PWA. The combination leaves Nostr rooms permanently dark after a transient socket drop.

These fixes introduce no change to public API. `makeSocket` gains an internal optional `onReconnect`. Torrent/MQTT pass nothing; only Nostr uses it.

I've noticed in passing that `ws-relay` has the same shape as bug, but opted to leave it alone to keep the PR smaller.

## Bugs

For ease of review, the first commit contains a failing test demonstrating each of these issues. Each commit then fixes a failure until everything is green again.

1. **Nostr batched subscriptions are sent once at join.** Socket reconnects don't re-flush the batcher. The new connection has no subs, room goes dark while `readyState === OPEN`.
2. **`queueAnnounce` has an unguarded `await`.** One rejection (transient WebCrypto failure, network blip) kills the loop forever (no logs or no retry).
3. **`makeSocket` backoff has no cap or jitter.** After ~10 closes the next retry is hours away; a relay restart synchronises every client into the same retry window.

## Testing

From the new tests:

| Test                   | Before                  | After        |
| ---------------------- | ----------------------- | ------------ |
| `nostr-resubscribe`    | 0 REQ re-sent           | ≥1 batched REQ |
| `announce-supervision` | loop dies after 1 call  | keeps firing |
| `socket-backoff`       | max delay 54,607,872 ms | ≤ 60,000 ms  |

Full Playwright suite (`pnpm test`, Chromium + Firefox): 12/12 strategy tests pass on both main and this branch. WebKit not run — playwright-webkit has no `RTCPeerConnection` on Windows.

## Relay load design considerations

I've tried to be mindful of the free-relay load in all fixes... the only one I am not certain about is the 60s back-off cap (as in: is the infinite backoff a feature?).

- No new traffic in steady state. Healthy clients hit relays exactly as before.
- Reconnect re-fires one batched REQ per relay (chunked at 250 topics each), regardless of room count. Jittered, no warmup burst.
- Backoff cap (60s): dead-relay load goes from once-per-hour-and-growing to one SYN/min.
- Full jitter on every retry so a relay restart doesn't synchronise the herd.
- Announce errors retry on the regular cadence.