### PR TITLE
Relay socket teardown: close sockets on leave to fix WebSocket leak

### DIFF
--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -55,7 +55,8 @@ export default <TRelay, TConfig extends BaseRoomConfig = JoinRoomConfig>({
   init,
   subscribe,
   announce,
-  deactivate
+  deactivate,
+  destroy
 }: StrategyAdapter<TRelay, TConfig>): JoinRoom<TConfig> => {
   const occupiedRooms: Record<
     string,
@@ -693,6 +694,7 @@ export default <TRelay, TConfig extends BaseRoomConfig = JoinRoomConfig>({
         }
 
         didInit = false
+        destroy?.()
         pool.destroy()
         offerPool = null
         cleanupWatchOnline()

--- a/packages/core/src/topic-strategy.ts
+++ b/packages/core/src/topic-strategy.ts
@@ -100,10 +100,12 @@ export default <TRelay, TConfig extends BaseRoomConfig = JoinRoomConfig>({
   init,
   subscribeTopic,
   publishTopic,
-  unpublishTopic
+  unpublishTopic,
+  destroy
 }: TopicStrategyAdapter<TRelay, TConfig>): JoinRoom<TConfig> =>
   createStrategy<TRelay, TConfig>({
     init,
+    ...(destroy ? {destroy} : {}),
 
     subscribe: async (
       relay,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -335,6 +335,7 @@ export type StrategyAdapter<
     selfTopic: string,
     context?: StrategyContext<TConfig>
   ) => MaybePromise<void>
+  destroy?: () => void
 }
 
 export type TopicStrategyAdapter<
@@ -359,6 +360,7 @@ export type TopicStrategyAdapter<
     topic: string,
     context: TopicPublishContext
   ) => MaybePromise<void>
+  destroy?: () => void
 }
 
 export type JoinRoom<TConfig extends BaseRoomConfig = JoinRoomConfig> = (
@@ -372,6 +374,7 @@ export type SocketClient = {
   url: string
   ready: Promise<SocketClient>
   send: (data: string) => void
+  close: () => void
 }
 
 export type RemoteTrackRef = {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -140,14 +140,23 @@ export const makeSocket = (
 ): SocketClient => {
   const client = {} as SocketClient
   let didOpen = false
+  let isClosed = false
   let resolveReady: (_: SocketClient) => void = noOp
 
   client.ready = new Promise(res => (resolveReady = res))
 
   const init = (): void => {
+    if (isClosed) {
+      return
+    }
+
     const socket = new WebSocket(url)
 
     socket.onclose = () => {
+      if (isClosed) {
+        return
+      }
+
       if (reconnectionLockingPromise) {
         void reconnectionLockingPromise.then(init)
         return
@@ -181,6 +190,19 @@ export const makeSocket = (
     }
   }
 
+  client.close = () => {
+    isClosed = true
+
+    const {socket} = client
+
+    if (socket) {
+      socket.onclose = null
+      socket.onmessage = null
+      socket.onopen = null
+      socket.close()
+    }
+  }
+
   init()
 
   return client
@@ -201,12 +223,14 @@ type RelayScopedStore<T, TRelay extends object> = {
 }
 
 export const createRelayManager = <TRelay extends object>(
-  getSocket: (relay: TRelay) => WebSocket | undefined
+  getSocket: (relay: TRelay) => WebSocket | undefined,
+  closeRelay?: (relay: TRelay) => void
 ): {
   register: (key: string, relay: TRelay) => TRelay
   keyOf: (relay: TRelay) => string
   scoped: <T>() => RelayScopedStore<T, TRelay>
   getSockets: () => Record<string, WebSocket>
+  reset: () => void
 } => {
   const relays: Record<string, TRelay> = {}
   const keysByRelay = new WeakMap<TRelay, string>()
@@ -247,7 +271,11 @@ export const createRelayManager = <TRelay extends object>(
 
           return socket ? [[key, socket]] : []
         })
-      ) as Record<string, WebSocket>
+      ) as Record<string, WebSocket>,
+    reset: () => {
+      values(relays).forEach(relay => closeRelay?.(relay))
+      keys(relays).forEach(key => delete relays[key])
+    }
   }
 }
 

--- a/packages/nostr/src/index.ts
+++ b/packages/nostr/src/index.ts
@@ -6,6 +6,7 @@ import {
   genId,
   getRelays,
   hashWith,
+  keys,
   libName,
   makeSocket,
   pauseRelayReconnection,
@@ -19,7 +20,10 @@ import {
   type SocketClient
 } from '@trystero-p2p/core'
 
-const relayManager = createRelayManager<SocketClient>(client => client.socket)
+const relayManager = createRelayManager<SocketClient>(
+  client => client.socket,
+  client => client.close()
+)
 const defaultRedundancy = 5
 const tag = 'x'
 const eventMsgType = 'EVENT'
@@ -271,7 +275,21 @@ export const joinRoom: JoinRoom<NostrRoomConfig> = createTopicStrategy({
   publishTopic: async (client, topic, msg) =>
     client.send(
       await createEvent(topic, typeof msg === 'string' ? msg : toJson(msg))
-    )
+    ),
+
+  destroy: () => {
+    relayManager.reset()
+
+    keys(batchers).forEach(url => {
+      const batcher = batchers[url]
+
+      if (batcher && batcher.updateTimer !== null) {
+        clearTimeout(batcher.updateTimer)
+      }
+
+      delete batchers[url]
+    })
+  }
 })
 
 export const getRelaySockets = relayManager.getSockets

--- a/packages/torrent/src/index.ts
+++ b/packages/torrent/src/index.ts
@@ -19,7 +19,10 @@ import {
   type SocketClient
 } from '@trystero-p2p/core'
 
-const relayManager = createRelayManager<SocketClient>(client => client.socket)
+const relayManager = createRelayManager<SocketClient>(
+  client => client.socket,
+  client => client.close()
+)
 const topicToInfoHash: Record<string, string> = {}
 const infoHashToTopic: Record<string, string> = {}
 const announceIntervals = relayManager.scoped<ReturnType<typeof setInterval>>()
@@ -459,6 +462,10 @@ const joinRoomStrategy: JoinRoom<TorrentRoomConfig> = createStrategy({
       }, dormantAnnounceMs)
       void fn()
     }
+  },
+
+  destroy: () => {
+    relayManager.reset()
   }
 })
 

--- a/packages/ws-relay/src/index.ts
+++ b/packages/ws-relay/src/index.ts
@@ -13,7 +13,10 @@ import {
   type StrategyMessage
 } from '@trystero-p2p/core'
 
-const relayManager = createRelayManager<SocketClient>(client => client.socket)
+const relayManager = createRelayManager<SocketClient>(
+  client => client.socket,
+  client => client.close()
+)
 const msgHandlers =
   relayManager.scoped<Set<(topic: string, data: StrategyMessage) => void>>()
 
@@ -124,7 +127,12 @@ export const joinRoom: JoinRoom<WsRelayRoomConfig> = createTopicStrategy({
     }
   },
 
-  publishTopic: (client, topic, msg) => client.send(toJson(publish(topic, msg)))
+  publishTopic: (client, topic, msg) =>
+    client.send(toJson(publish(topic, msg))),
+
+  destroy: () => {
+    relayManager.reset()
+  }
 })
 
 export const getRelaySockets = relayManager.getSockets

--- a/test/node/relay-socket-leak.spec.ts
+++ b/test/node/relay-socket-leak.spec.ts
@@ -1,0 +1,203 @@
+// @ts-nocheck
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {makeSocket} from '../../packages/core/src/utils.ts'
+import {joinRoom as joinNostrRoom} from '../../packages/nostr/src/index.ts'
+import {joinRoom as joinTorrentRoom} from '../../packages/torrent/src/index.ts'
+import {joinRoom as joinWsRelayRoom} from '../../packages/ws-relay/src/index.ts'
+
+const wait = (ms: number) => new Promise(res => setTimeout(res, ms))
+
+const waitFor = async (
+  check: () => boolean,
+  timeoutMs = 2_000
+): Promise<void> => {
+  const start = Date.now()
+
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition')
+    }
+
+    await wait(10)
+  }
+}
+
+class AutoOpenWebSocket {
+  static sockets = []
+
+  readyState = 0
+  sent = []
+  onopen = null
+  onclose = null
+  onmessage = null
+  url
+
+  constructor(url) {
+    this.url = url
+    AutoOpenWebSocket.sockets.push(this)
+
+    setTimeout(() => {
+      this.readyState = 1
+      this.onopen?.()
+    }, 0)
+  }
+
+  send(data) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = 3
+    this.onclose?.()
+  }
+}
+
+const openSockets = () =>
+  AutoOpenWebSocket.sockets.filter(socket => socket.readyState !== 3)
+
+void test(
+  'Trystero: a socket client can be torn down so it stops reconnecting',
+  {timeout: 5_000},
+  async () => {
+    const realWebSocket = globalThis.WebSocket
+    const realSetTimeout = globalThis.setTimeout
+
+    const sockets = []
+    let pendingInit = null
+
+    class ManualSocket {
+      readyState = 0
+      onopen = null
+      onclose = null
+      onmessage = null
+      url
+
+      constructor(url) {
+        this.url = url
+        sockets.push(this)
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = 3
+        this.onclose?.()
+      }
+    }
+
+    try {
+      globalThis.WebSocket = ManualSocket
+      // Capture the reconnect timer so we can fire it deterministically.
+      globalThis.setTimeout = fn => {
+        pendingInit = fn
+        return 0
+      }
+
+      const client = makeSocket(`ws://socket-teardown-${Date.now()}`, () => {})
+      assert.equal(sockets.length, 1, 'makeSocket should open one socket')
+
+      assert.equal(
+        typeof client.close,
+        'function',
+        'makeSocket should expose a close() teardown so a discarded client can be stopped'
+      )
+
+      // Drop the socket so makeSocket schedules a reconnect, then tear the
+      // client down. The pending reconnect must not resurrect the socket —
+      // this is the loop that, left running across re-joins, exhausts the
+      // browser's per-host WebSocket budget ("Insufficient resources").
+      sockets[0].close()
+      client.close()
+
+      if (pendingInit) {
+        const stale = pendingInit
+        pendingInit = null
+        stale()
+      }
+
+      assert.equal(
+        sockets.length,
+        1,
+        'a closed socket client must not open further sockets, even if a reconnect was already scheduled'
+      )
+    } finally {
+      globalThis.WebSocket = realWebSocket
+      globalThis.setTimeout = realSetTimeout
+    }
+  }
+)
+
+// Every socket-backed transport shares the same relay lifecycle: leaving the
+// last room resets the strategy's didInit, so the next join re-runs init and
+// opens fresh sockets. If leave() doesn't close the sockets init() opened, each
+// cycle orphans a live socket (and its reconnect loop) until the browser
+// refuses new ones with "Insufficient resources".
+const runSocketLeakTests = (
+  strategy: string,
+  joinRoom: typeof joinNostrRoom
+): void => {
+  const makeConfig = (suffix: string) => ({
+    appId: `socket-leak-${strategy}-${suffix}-${Date.now()}`,
+    passive: true,
+    relayConfig: {urls: [`wss://socket-leak-${strategy}-${suffix}.test`]}
+  })
+
+  void test(
+    `Trystero: ${strategy} leaving a room closes its relay sockets`,
+    {timeout: 10_000},
+    async () => {
+      const realWebSocket = globalThis.WebSocket
+
+      globalThis.WebSocket = AutoOpenWebSocket
+      AutoOpenWebSocket.sockets.length = 0
+
+      try {
+        const room = joinRoom(makeConfig('leave'), 'room')
+        await waitFor(() => AutoOpenWebSocket.sockets.length >= 1)
+        await room.leave().catch(() => {})
+
+        assert.equal(
+          openSockets().length,
+          0,
+          `${strategy}: room.leave() should close every relay socket it opened`
+        )
+      } finally {
+        globalThis.WebSocket = realWebSocket
+      }
+    }
+  )
+
+  void test(
+    `Trystero: ${strategy} repeated join/leave cycles do not accumulate open relay sockets`,
+    {timeout: 15_000},
+    async () => {
+      const realWebSocket = globalThis.WebSocket
+
+      globalThis.WebSocket = AutoOpenWebSocket
+      AutoOpenWebSocket.sockets.length = 0
+
+      const config = makeConfig('cycles')
+
+      try {
+        for (let cycle = 0; cycle < 5; cycle += 1) {
+          const room = joinRoom(config, 'room')
+          await waitFor(() => AutoOpenWebSocket.sockets.length >= cycle + 1)
+
+          assert.ok(
+            openSockets().length <= 1,
+            `${strategy} cycle ${cycle}: expected at most one open relay socket, found ${openSockets().length}`
+          )
+
+          await room.leave().catch(() => {})
+        }
+      } finally {
+        globalThis.WebSocket = realWebSocket
+      }
+    }
+  )
+}
+
+runSocketLeakTests('nostr', joinNostrRoom)
+runSocketLeakTests('torrent', joinTorrentRoom)
+runSocketLeakTests('ws-relay', joinWsRelayRoom)


### PR DESCRIPTION
(Claude helped again, just for disclosure)

Follow-up to #178. On the same Android/kiosk PWA, reconnection eventually dies with
  `new WebSocket(url)` throwing "Insufficient resources".

  ## Bug

  `room.leave()` never closes the relay sockets, and `makeSocket`'s per-URL reconnect loop has no
  teardown. Because a single-room leave resets the strategy's `didInit`, the next `joinRoom()` re-runs
  `init` and opens fresh sockets — orphaning the previous socket and its still-live reconnect loop.
  Any leave→rejoin (a reconnect loop, room switch, or a flaky relay) leaks one socket per cycle until
  the browser refuses new ones. Affects nostr, torrent and ws-relay.

  (Latent before #178; the 60s backoff cap surfaced it — orphaned loops now retry forever instead of
  decaying to multi-hour dormancy.)

  ## Fix

  Per-package commits, failing tests first:

  - **core** — `makeSocket` gains `close()` with an `isClosed` guard that also cancels an
    already-scheduled reconnect; `createRelayManager` gains `closeRelay` + `reset()`; the strategy
    fires a new optional `destroy()` hook on the last-room-leave.
  - **nostr / torrent / ws-relay** — wire `destroy: () => relayManager.reset()`.

  No public API change; `destroy` is optional and mqtt is untouched.

  ## Testing

  New `relay-socket-leak.spec.ts`, run across all three transports:

  | Test                  | Before                                    | After             |
  | --------------------- | ----------------------------------------- | ----------------- |
  | socket teardown       | a scheduled reconnect reopens the socket  | `close()` stops it |
  | leave closes sockets  | 1 socket still open after `leave()`       | 0 open            |
  | repeated join/leave   | open sockets climb +1 per cycle           | stays ≤ 1         |

  Before the fix the test process also hangs (orphaned timers keep the event loop alive); after, it
  exits cleanly. `typecheck` and `oxfmt` clean.