### PR TITLE
add open.ftorrent.com to defaultRelayUrls

### DIFF
--- a/packages/torrent/src/index.ts
+++ b/packages/torrent/src/index.ts
@@ -483,7 +483,8 @@ export const defaultRelayUrls = [
   'tracker.webtorrent.dev',
   'tracker.openwebtorrent.com',
   'tracker.btorrent.xyz',
-  'tracker.files.fm:7073/announce'
+  'tracker.files.fm:7073/announce',
+  'open.ftorrent.com'
 ].map(url => 'wss://' + url)
 
 export type * from '@trystero-p2p/core'


### PR DESCRIPTION
Hi Dan — nice to meet you. I'm connecting open.ftorrent.com, the open tracker at the start of my broader decentralized computing project, to more of the ecosystem it can serve — and Trystero is my favorite thing anyone has built on tracker infrastructure: room-based matchmaking for the open web, no servers of your own, is exactly what this public commons is for. I'd like to add some capacity to it.

This adds `open.ftorrent.com` to `defaultRelayUrls` in `@trystero-p2p/torrent`.

It's an [Aquatic](https://github.com/greatest-ape/aquatic) WebSocket tracker — the same software as `tracker.webtorrent.dev` — that I operate, with the deployment public at [zootella/ftorrent](https://github.com/zootella/ftorrent/tree/master/open) and live stats at [open.ftorrent.com](https://open.ftorrent.com/) (machine-readable: [page.json](https://open.ftorrent.com/page.json)). It passes `pnpm test:relays` (272ms from here). Happy to have it removed if it ever misbehaves.
